### PR TITLE
Add function to load OpenType font tables

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -274,6 +274,9 @@ pub trait Loader: Clone + Sized {
     ///
     /// The `locale` argument is a language tag such as `"en-US"` or `"zh-Hans-CN"`.
     fn get_fallbacks(&self, text: &str, locale: &str) -> FallbackResult<Self>;
+
+    /// Returns the OpenType font table with the given tag, if the table exists.
+    fn load_font_table(&self, table_tag: u32) -> Option<Box<[u8]>>;
 }
 
 /// The result of a fallback query.

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -586,7 +586,9 @@ impl Font {
 
     #[inline]
     pub fn load_font_table(&self, table_tag: u32) -> Option<Box<[u8]>> {
-        self.core_text_font.get_font_table(table_tag).map(|data| data.bytes().into())
+        self.core_text_font
+            .get_font_table(table_tag)
+            .map(|data| data.bytes().into())
     }
 }
 

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -583,6 +583,11 @@ impl Font {
     fn units_per_point(&self) -> f64 {
         (self.core_text_font.units_per_em() as f64) / self.core_text_font.pt_size()
     }
+
+    #[inline]
+    pub fn load_font_table(&self, table_tag: u32) -> Option<Box<[u8]>> {
+        self.core_text_font.get_font_table(table_tag).map(|data| data.bytes().into())
+    }
 }
 
 impl Loader for Font {
@@ -730,6 +735,11 @@ impl Loader for Font {
     #[inline]
     fn get_fallbacks(&self, text: &str, locale: &str) -> FallbackResult<Self> {
         self.get_fallbacks(text, locale)
+    }
+
+    #[inline]
+    fn load_font_table(&self, table_tag: u32) -> Option<Box<[u8]>> {
+        self.load_font_table(table_tag)
     }
 }
 

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -618,6 +618,10 @@ impl Font {
         };
         FallbackResult { fonts, valid_len }
     }
+
+    pub fn load_font_table(&self, table_tag: u32) -> Option<Box<[u8]>> {
+        self.dwrite_font_face.get_font_table(table_tag).map(|v| v.into())
+    }
 }
 
 // There might well be a more efficient impl that doesn't fully decode the text,
@@ -794,6 +798,11 @@ impl Loader for Font {
     #[inline]
     fn get_fallbacks(&self, text: &str, locale: &str) -> FallbackResult<Self> {
         self.get_fallbacks(text, locale)
+    }
+
+    #[inline]
+    fn load_font_table(&self, table_tag: u32) -> Option<Box<[u8]>> {
+        self.load_font_table(table_tag)
     }
 }
 

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -620,7 +620,9 @@ impl Font {
     }
 
     pub fn load_font_table(&self, table_tag: u32) -> Option<Box<[u8]>> {
-        self.dwrite_font_face.get_font_table(table_tag).map(|v| v.into())
+        self.dwrite_font_face
+            .get_font_table(table_tag)
+            .map(|v| v.into())
     }
 }
 

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -19,7 +19,7 @@ use freetype::freetype::{FT_Byte, FT_Done_Face, FT_Error, FT_Face, FT_FACE_FLAG_
 use freetype::freetype::{FT_Fixed, FT_Matrix, FT_UShort, FT_Vector};
 use freetype::freetype::{FT_Get_Char_Index, FT_Get_Name_Index, FT_Get_Postscript_Name};
 use freetype::freetype::{
-    FT_Get_Sfnt_Table, FT_Load_Sfnt_Table, FT_Init_FreeType, FT_LOAD_DEFAULT, FT_LOAD_MONOCHROME,
+    FT_Get_Sfnt_Table, FT_Init_FreeType, FT_Load_Sfnt_Table, FT_LOAD_DEFAULT, FT_LOAD_MONOCHROME,
 };
 use freetype::freetype::{FT_LcdFilter, FT_Library_SetLcdFilter};
 use freetype::freetype::{FT_Library, FT_Load_Glyph, FT_Long, FT_LOAD_NO_HINTING, FT_LOAD_RENDER};
@@ -924,12 +924,24 @@ impl Font {
         unsafe {
             let mut len = 0;
 
-            if 0 != FT_Load_Sfnt_Table(self.freetype_face, table_tag as FT_ULong, 0, ptr::null_mut(), &mut len) {
+            if 0 != FT_Load_Sfnt_Table(
+                self.freetype_face,
+                table_tag as FT_ULong,
+                0,
+                ptr::null_mut(),
+                &mut len,
+            ) {
                 return None;
             }
 
             let mut buf = Box::<[u8]>::from(vec![0; len as usize]);
-            if 0 != FT_Load_Sfnt_Table(self.freetype_face, table_tag as FT_ULong, 0, buf.as_mut_ptr() as *mut FT_Byte, &mut len) {
+            if 0 != FT_Load_Sfnt_Table(
+                self.freetype_face,
+                table_tag as FT_ULong,
+                0,
+                buf.as_mut_ptr() as *mut FT_Byte,
+                &mut len,
+            ) {
                 return None;
             }
 


### PR DESCRIPTION
Fixes #35.

I'm unable to actually test this implementation for macOS, since I don't have convenient access to a macOS system. That being said, if it compiles I don't see any reason why this particular implementation wouldn't work.