### PR TITLE
Fix build failure when downstream crates attempt to build font-kit on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ dwrote = { version = "0.9", default-features = false }
 
 [target.'cfg(target_family = "windows")'.dependencies.winapi]
 version = "0.3"
-features = ["minwindef", "winbase"]
+features = ["minwindef", "winbase", "sysinfoapi"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ dwrote = { version = "0.9", default-features = false }
 
 [target.'cfg(target_family = "windows")'.dependencies.winapi]
 version = "0.3"
-features = ["minwindef", "winbase", "sysinfoapi"]
+features = ["dwrite", "minwindef", "sysinfoapi", "winbase", "winnt"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.6"


### PR DESCRIPTION
When de6fabc got merged, the dependency that loaded `winapi`'s `sysinfoapi` feature got removed. This fails builds when attempting to build `font-kit` downstream (i.e. if you depend on `git = "https://github.com/pcwalton/font-kit.git"` through `Cargo.toml`), but it does *not* fail when you run `cargo build` within `font-kit`'s folder directly.

I don't know why cargo behaves that way. I assume it's a bug. Still, this fixes that behavior by making the `sysinfoapi` dependency explicit. For good measure, we make all the other `winapi` dependency features explicit to ensure this same sort of issue doesn't happen again.