### PR TITLE
Use top-left as the origin for raster bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT/Apache-2.0"

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -180,7 +180,8 @@ pub trait Loader: Clone + Sized {
     where
         B: PathBuilder;
 
-    /// Returns the boundaries of a glyph in font units.
+    /// Returns the boundaries of a glyph in font units. The origin of the coordinate
+    /// space is at the bottom left.
     fn typographic_bounds(&self, glyph_id: u32) -> Result<Rect<f32>, GlyphLoadingError>;
 
     /// Returns the distance from the origin of the glyph with the given ID to the next, in font
@@ -222,7 +223,7 @@ pub trait Loader: Clone + Sized {
 
     /// Returns the pixel boundaries that the glyph will take up when rendered using this loader's
     /// rasterizer at the given `point_size`, `transform` and `origin`. `origin` is not transformed
-    /// by `transform`.
+    /// by `transform`. The origin of the coordinate space is at the top left.
     fn raster_bounds(
         &self,
         glyph_id: u32,
@@ -233,8 +234,10 @@ pub trait Loader: Clone + Sized {
         _: RasterizationOptions,
     ) -> Result<Rect<i32>, GlyphLoadingError> {
         let typographic_bounds = self.typographic_bounds(glyph_id)?;
-        let typographic_raster_bounds =
+        let mut typographic_raster_bounds =
             typographic_bounds * point_size / self.metrics().units_per_em as f32;
+        typographic_raster_bounds.origin.y =
+            -typographic_raster_bounds.origin.y - typographic_raster_bounds.size.height;
         let transform: Transform2D<f32> = Transform2D::column_major(
             transform.scale_x,
             transform.skew_x,

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -410,7 +410,7 @@ impl Font {
         let texture_height = texture_bounds.bottom - texture_bounds.top;
 
         Ok(Rect::new(
-            Point2D::new(texture_bounds.left, -texture_height - texture_bounds.top),
+            Point2D::new(texture_bounds.left, texture_bounds.top),
             Size2D::new(texture_width, texture_height).to_i32(),
         ))
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -502,11 +502,7 @@ pub fn rasterize_glyph_with_grayscale_aa() {
             RasterizationOptions::GrayscaleAa,
         )
         .unwrap();
-    let origin = Point2D::new(
-        -raster_rect.origin.x,
-        raster_rect.size.height + raster_rect.origin.y,
-    )
-    .to_f32();
+    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
     let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
     font.rasterize_glyph(
         &mut canvas,
@@ -540,11 +536,7 @@ pub fn rasterize_glyph_bilevel() {
             RasterizationOptions::Bilevel,
         )
         .unwrap();
-    let origin = Point2D::new(
-        -raster_rect.origin.x,
-        raster_rect.size.height + raster_rect.origin.y,
-    )
-    .to_f32();
+    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
     let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
     font.rasterize_glyph(
         &mut canvas,
@@ -556,6 +548,45 @@ pub fn rasterize_glyph_bilevel() {
         RasterizationOptions::Bilevel,
     )
     .unwrap();
+    assert!(canvas
+        .pixels
+        .iter()
+        .all(|&value| value == 0 || value == 0xff));
+    check_L_shape(&canvas);
+}
+
+#[test]
+pub fn rasterize_glyph_bilevel_offset() {
+    let font = SystemSource::new()
+        .select_best_match(&[FamilyName::SansSerif], &Properties::new())
+        .unwrap()
+        .load()
+        .unwrap();
+    let glyph_id = font.glyph_for_char('L').unwrap();
+    let size = 32.0;
+    let raster_rect = font
+        .raster_bounds(
+            glyph_id,
+            size,
+            &FontTransform::identity(),
+            &point2(30., 100.),
+            HintingOptions::None,
+            RasterizationOptions::Bilevel,
+        )
+        .unwrap();
+    let origin = Point2D::new(-raster_rect.origin.x + 30, -raster_rect.origin.y + 100).to_f32();
+    let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
+    font.rasterize_glyph(
+        &mut canvas,
+        glyph_id,
+        size,
+        &FontTransform::identity(),
+        &origin,
+        HintingOptions::None,
+        RasterizationOptions::Bilevel,
+    )
+    .unwrap();
+
     assert!(canvas
         .pixels
         .iter()
@@ -586,11 +617,7 @@ pub fn rasterize_glyph_with_full_hinting() {
             RasterizationOptions::Bilevel,
         )
         .unwrap();
-    let origin = Point2D::new(
-        -raster_rect.origin.x,
-        raster_rect.size.height + raster_rect.origin.y,
-    )
-    .to_f32();
+    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
     let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
     font.rasterize_glyph(
         &mut canvas,
@@ -641,11 +668,7 @@ pub fn rasterize_glyph() {
             RasterizationOptions::GrayscaleAa,
         )
         .unwrap();
-    let origin = Point2D::new(
-        -raster_rect.origin.x,
-        raster_rect.size.height + raster_rect.origin.y,
-    )
-    .to_f32();
+    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
     let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
     font.rasterize_glyph(
         &mut canvas,
@@ -691,8 +714,8 @@ pub fn font_transform() {
         .unwrap();
     assert!((raster_rect2.size.width - raster_rect.size.width * 3).abs() <= 3);
     assert!((raster_rect2.size.height - raster_rect.size.height * 3).abs() <= 3);
-    assert!((raster_rect2.origin.x - raster_rect.origin.x).abs() <= 3);
-    assert!((raster_rect2.origin.y - raster_rect.origin.y).abs() <= 3);
+    assert!((raster_rect2.origin.x - ((raster_rect.origin.x - 8) * 3 + 8)).abs() <= 3);
+    assert!((raster_rect2.origin.y - ((raster_rect.origin.y - 8) * 3 + 8)).abs() <= 3);
 }
 
 #[test]


### PR DESCRIPTION
This fixes the origin mismatch that happens in the fallback
implementation of raster_bounds() and matches the origin of the canvas
which makes the api more usable.

The major version is bumped because of the behaviour change.