### PR TITLE
Stop panicking when rasterizing to a zero-size canvas in the Core Text backend.

### DIFF
--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -467,6 +467,10 @@ impl Font {
         hinting_options: HintingOptions,
         rasterization_options: RasterizationOptions,
     ) -> Result<(), GlyphLoadingError> {
+        if canvas.size.width == 0 || canvas.size.height == 0 {
+            return Ok(());
+        }
+
         let (cg_color_space, cg_image_format) =
             match format_to_cg_color_space_and_image_format(canvas.format) {
                 None => {
@@ -532,7 +536,7 @@ impl Font {
             Format::A8 => core_graphics_context.set_gray_fill_color(1.0, 1.0),
         }
 
-        //CoreGraphics origin is in the bottom left. This makes behavior consistent.
+        // CoreGraphics origin is in the bottom left. This makes behavior consistent.
         core_graphics_context.translate(0., canvas.size.height as CGFloat);
         core_graphics_context.set_font(&self.core_text_font.copy_to_CGFont());
         core_graphics_context.set_font_size(point_size as CGFloat);

--- a/src/test.rs
+++ b/src/test.rs
@@ -707,6 +707,58 @@ pub fn rasterize_glyph() {
     check_curly_shape(&canvas);
 }
 
+// Tests that an empty glyph can be successfully rasterized to a 0x0 canvas (issue #7).
+#[test]
+pub fn rasterize_empty_glyph() {
+    let mut file = File::open(TEST_FONT_FILE_PATH).unwrap();
+    let font = Font::from_file(&mut file, 0).unwrap();
+    let glyph = font.glyph_for_char(' ').expect("No glyph for char!");
+    let raster_rect = Rect::new(Point2D::new(0.0, 0.0), Size2D::new(16.0, 16.0));
+    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
+    let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
+    font.rasterize_glyph(
+        &mut canvas,
+        glyph,
+        16.0,
+        &FontTransform::identity(),
+        &origin,
+        HintingOptions::None,
+        RasterizationOptions::GrayscaleAa,
+    )
+    .unwrap();
+}
+
+// Tests that an empty glyph can be successfully rasterized to a 0x0 canvas (issue #7).
+#[test]
+pub fn rasterize_empty_glyph_on_empty_canvas() {
+    let mut file = File::open(TEST_FONT_FILE_PATH).unwrap();
+    let font = Font::from_file(&mut file, 0).unwrap();
+    let glyph = font.glyph_for_char(' ').expect("No glyph for char!");
+    let size = 32.0;
+    let raster_rect = font
+        .raster_bounds(
+            glyph,
+            size,
+            &FontTransform::identity(),
+            &Point2D::zero(),
+            HintingOptions::None,
+            RasterizationOptions::GrayscaleAa,
+        )
+        .unwrap();
+    let origin = Point2D::new(-raster_rect.origin.x, -raster_rect.origin.y).to_f32();
+    let mut canvas = Canvas::new(&raster_rect.size.to_u32(), Format::A8);
+    font.rasterize_glyph(
+        &mut canvas,
+        glyph,
+        size,
+        &FontTransform::identity(),
+        &origin,
+        HintingOptions::None,
+        RasterizationOptions::GrayscaleAa,
+    )
+    .unwrap();
+}
+
 #[test]
 pub fn font_transform() {
     let font = SystemSource::new()


### PR DESCRIPTION
Closes #7.