### PR TITLE
Expose the global glyph bounding box through the `metrics()` method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ pbr = "1.0"
 prettytable-rs = "0.8"
 
 [target.'cfg(target_family = "windows")'.dependencies]
-dwrote = { version = "0.9", default-features = false }
+dwrote = { version = "0.10", default-features = false }
 
 [target.'cfg(target_family = "windows")'.dependencies.winapi]
 version = "0.3"

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -390,6 +390,17 @@ impl Font {
     pub fn metrics(&self) -> Metrics {
         let units_per_em = self.core_text_font.units_per_em();
         let units_per_point = (units_per_em as f64) / self.core_text_font.pt_size();
+
+        let bounding_box = self.core_text_font.bounding_box();
+        let bounding_box_origin = Point2D::new(
+            (bounding_box.origin.x * units_per_point) as f32,
+            (bounding_box.origin.y * units_per_point) as f32,
+        );
+        let bounding_box_size = Size2D::new(
+            (bounding_box.size.width * units_per_point) as f32,
+            (bounding_box.size.height * units_per_point) as f32,
+        );
+
         Metrics {
             units_per_em,
             ascent: (self.core_text_font.ascent() * units_per_point) as f32,
@@ -400,6 +411,7 @@ impl Font {
                 as f32,
             cap_height: (self.core_text_font.cap_height() * units_per_point) as f32,
             x_height: (self.core_text_font.x_height() * units_per_point) as f32,
+            bounding_box: Rect::new(bounding_box_origin, bounding_box_size),
         }
     }
 

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -643,6 +643,7 @@ impl Font {
             let descender = (*self.freetype_face).descender;
             let underline_position = (*self.freetype_face).underline_position;
             let underline_thickness = (*self.freetype_face).underline_thickness;
+            let bbox = (*self.freetype_face).bbox;
             Metrics {
                 units_per_em: (*self.freetype_face).units_per_EM as u32,
                 ascent: ascender as f32,
@@ -656,6 +657,13 @@ impl Font {
                 x_height: os2_table
                     .map(|table| (*table).sxHeight as f32)
                     .unwrap_or(0.0),
+                bounding_box: Rect::new(
+                    Point2D::new(bbox.xMin as f32, bbox.yMin as f32),
+                    Size2D::new(
+                        bbox.xMax as f32 - bbox.xMin as f32,
+                        bbox.yMax as f32 - bbox.yMin as f32,
+                    ),
+                ),
             }
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,6 +12,8 @@
 //!
 //! For OpenType fonts, these mostly come from the `OS/2` table.
 
+use euclid::default::Rect;
+
 /// Various metrics that apply to the entire font.
 ///
 /// For OpenType fonts, these mostly come from the `OS/2` table.
@@ -48,4 +50,9 @@ pub struct Metrics {
     /// The approximate amount that non-ascending lowercase letters rise above the baseline, in
     /// font units.
     pub x_height: f32,
+
+    /// A rectangle that surrounds all bounding boxes of all glyphs, in font units.
+    ///
+    /// This corresponds to the `xMin`/`xMax`/`yMin`/`yMax` values in the OpenType `head` table.
+    pub bounding_box: Rect<f32>,
 }


### PR DESCRIPTION
Closes #29.