### PR TITLE
Sources: add flatpak specific paths

### DIFF
--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -182,6 +182,8 @@ fn default_font_directories() -> Vec<PathBuf> {
     let mut directories = vec![
         PathBuf::from("/usr/share/fonts"),
         PathBuf::from("/usr/local/share/fonts"),
+        PathBuf::from("/var/run/host/usr/share/fonts"),
+        PathBuf::from("/var/run/host/usr/local/share/fonts"),
     ];
     if let Some(mut path) = dirs::home_dir() {
         path.push(".fonts");

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -182,12 +182,12 @@ fn default_font_directories() -> Vec<PathBuf> {
     let mut directories = vec![
         PathBuf::from("/usr/share/fonts"),
         PathBuf::from("/usr/local/share/fonts"),
-        PathBuf::from("/var/run/host/usr/share/fonts"),
+        PathBuf::from("/var/run/host/usr/share/fonts"), // Flatpak specific
         PathBuf::from("/var/run/host/usr/local/share/fonts"),
     ];
-    if let Some(mut path) = dirs::home_dir() {
-        path.push(".fonts"); // ~/.fonts is deprecated
-        directories.push(path);
+    if let Some(path) = dirs::home_dir() {
+        directories.push(path.join(".fonts")); // ~/.fonts is deprecated
+        directories.push(path.join("local").join("share").join("fonts")); // Flatpak specific
     }
     if let Some(mut path) = dirs::data_dir() {
         path.push("fonts");

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -186,7 +186,11 @@ fn default_font_directories() -> Vec<PathBuf> {
         PathBuf::from("/var/run/host/usr/local/share/fonts"),
     ];
     if let Some(mut path) = dirs::home_dir() {
-        path.push(".fonts");
+        path.push(".fonts"); // ~/.fonts is deprecated
+        directories.push(path);
+    }
+    if let Some(mut path) = dirs::data_dir() {
+        path.push("fonts");
         directories.push(path);
     }
     directories


### PR DESCRIPTION
I'm working on a font manager that uses font-kit and distributed using [Flatpak](flatpak.org/), this patch should allow reading fonts from outside the sandboxed too if the access to the path is given using `--filesystem=/usr/share/fonts:ro` in the application manifest.

The path is mounted later under `/var/host/run/$path`
