### PR TITLE
Ignore a test that depends on fonts not always available.

### DIFF
--- a/tests/select_font.rs
+++ b/tests/select_font.rs
@@ -161,7 +161,9 @@ mod test {
         }
     }
 
+    // This test fails on TravisCI's Windows environment.
     #[test]
+    #[ignore]
     fn select_localized_family_name() {
         let handle = SystemSource::new()
             .select_best_match(


### PR DESCRIPTION
This should fix #135.