### PR TITLE
bump servo-fontconfig to v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ version = "^0.4.1"
 optional = true
 
 [dependencies.servo-fontconfig]
-version = "0.4"
+version = "0.5"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
The old version of `fontconfig` can't parse the config files on newer operating systems (like Ubuntu 19.10 or 20.04) and applications that use it take a ton of time to load (about 1 minute in my case) after encountering these problems.

The issue is fixed by updating the version of `servo-fontconfig` in `Cargo.toml`, which in turn links to a newer version of `fontconfig` itself.