### PR TITLE
Upgrade FreeType dep from 0.4.1 to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ pathfinder_geometry = "0.5"
 pathfinder_simd = "0.5"
 
 [dependencies.freetype]
-version = "^0.4.1"
+version = "^0.5.1"
 optional = true
 
 [dependencies.servo-fontconfig]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,6 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate log;
 
 pub mod canvas;
 pub mod error;


### PR DESCRIPTION
Hello!

I also needed the change seen in #144, so I decided to open my own PR.  Are you open to bumping this version?  In my project, I am trying to use [servo/rust-freetype](https://github.com/servo/rust-freetype) v0.5.1, but since `font-kit` currently depends on FreeType v0.4.1 I get this error during compilation:

```
error: multiple packages link to native library `freetype`, but a native library can be linked only once

package `freetype-sys v0.11.0`
    ... which is depended on by `freetype v0.5.1`
    ... which is depended on by `kosmonaut v0.1.0 (/home/twilco/projects/kosmonaut)`
links to native library `freetype`

package `servo-freetype-sys v4.0.3`
    ... which is depended on by `freetype v0.4.1`
    ... which is depended on by `font-kit v0.7.1`
    ... which is depended on by `kosmonaut v0.1.0 (/home/twilco/projects/kosmonaut)`
also links to native library `freetype`
```

I could probably downgrade my `rust-freetype` version, but wanted to try this first.