### PR TITLE
Bump version from 0.7.1 to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.7.1"
+version = "0.8.1"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.8.1"
+version = "0.8.0"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Hello again.  Whenever it's convenient, a release following the merge of #150 would be greatly appreciated.  I bumped a minor version since #150 bumped FreeType a minor version.  Thanks!