### PR TITLE
Add a minimal versions build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
       dist: xenial
     - os: osx
     - os: windows
+    - rust: nightly
+      name: minimal-versions
+      script:
+        - cargo -Z minimal-versions build --verbose
 rust:
   - stable
 install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ byteorder = "1.2"
 float-ord = "0.2"
 lazy_static = "1.1"
 libc = "0.2"
-log = "0.4"
+log = "0.4.4"
 pathfinder_geometry = "0.5"
 pathfinder_simd = "0.5"
 


### PR DESCRIPTION
This also requires log 0.4.4 as older
versions don't build with rust anymore.