### PR TITLE
Avoid a permission error matching fonts under UWP.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT/Apache-2.0"

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -731,6 +731,13 @@ impl Loader for Font {
         Font::from_file(file, font_index)
     }
 
+    fn from_path<P>(path: P, font_index: u32) -> Result<Self, FontLoadingError>
+    where
+        P: AsRef<Path>,
+    {
+        Font::from_path(path, font_index)
+    }
+
     #[inline]
     unsafe fn from_native_font(native_font: Self::NativeFont) -> Self {
         Font::from_native_font(native_font)

--- a/src/source.rs
+++ b/src/source.rs
@@ -143,8 +143,9 @@ pub trait Source {
     ) -> Result<Vec<Properties>, SelectionError> {
         let mut fields = vec![];
         for font_handle in family.fonts() {
-            if let Ok(font) = Font::from_handle(font_handle) {
-                fields.push(font.properties())
+            match Font::from_handle(font_handle) {
+                Ok(font) => fields.push(font.properties()),
+                Err(e) => log::warn!("Error loading font from handle: {:?}", e),
             }
         }
         Ok(fields)


### PR DESCRIPTION
Fonts like "Times New Roman" resolve to a path like C:\WINDOWS\FONTS\TIMES NEW ROMAN.TTF.
Strangely, UWP permits opening these paths, but not calling GetFinalPathNameByHandleW on
a file handle that has been opened to it. The current code path is both inefficent (we
use a path to open a file, then attempt to get the path again from that file handle) and
broken, so when a path is available we can pass it directly to DirectWrite and avoid the
entire problem.