### PR TITLE
Add auto-derive Hash to FamilyName and Properties.

### DIFF
--- a/src/family_name.rs
+++ b/src/family_name.rs
@@ -16,7 +16,7 @@
 /// https://drafts.csswg.org/css-fonts-3/#font-family-prop.
 ///
 /// TODO(pcwalton): `system-ui`, `emoji`, `math`, `fangsong`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Hash)]
 pub enum FamilyName {
     /// A specific font family, specified by name: e.g. "Arial", "times".
     Title(String),

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 ///
 ///     # use font_kit::properties::{Properties, Style};
 ///     println!("{:?}", Properties::new().style(Style::Italic));
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Hash)]
 pub struct Properties {
     /// The font style, as defined in CSS.
     pub style: Style,


### PR DESCRIPTION
Useful if you want to keep a cache of loaded fonts.