### PR TITLE
Add method to add to a `MemSource` after creation.

### DIFF
--- a/src/sources/mem.rs
+++ b/src/sources/mem.rs
@@ -34,14 +34,7 @@ impl MemSource {
     {
         let mut families = vec![];
         for handle in fonts {
-            let font = Font::from_handle(&handle)?;
-            if let Some(postscript_name) = font.postscript_name() {
-                families.push(FamilyEntry {
-                    family_name: font.family_name(),
-                    postscript_name: postscript_name,
-                    font: handle,
-                })
-            }
+            add_font(handle, &mut families)?;
         }
         families.sort_by(|a, b| a.family_name.cmp(&b.family_name));
         Ok(MemSource { families })
@@ -53,13 +46,23 @@ impl MemSource {
     /// `Handle` iterator, since this method sorts after every addition, rather than once at the
     /// end.
     pub fn add_font(&mut self, handle: Handle) -> Result<(), FontLoadingError> {
-        let font = Font::from_handle(&handle)?;
-        if let Some(postscript_name) = font.postscript_name() {
-            self.families.push(FamilyEntry {
-                family_name: font.family_name(),
-                postscript_name: postscript_name,
-                font: handle,
-            })
+        add_font(handle, &mut self.families)?;
+        self.families
+            .sort_by(|a, b| a.family_name.cmp(&b.family_name));
+        Ok(())
+    }
+
+    /// Add a number of existing font handles to a `MemSource`.
+    ///
+    /// Note that adding fonts to an existing `MemSource` is slower than creating a new one from a
+    /// `Handle` iterator, because extra unnecessary sorting with occur with every call to this
+    /// method.
+    pub fn add_fonts(
+        &mut self,
+        handles: impl Iterator<Item = Handle>,
+    ) -> Result<(), FontLoadingError> {
+        for handle in handles {
+            add_font(handle, &mut self.families)?;
         }
         self.families
             .sort_by(|a, b| a.family_name.cmp(&b.family_name));
@@ -162,6 +165,19 @@ impl Source for MemSource {
     fn select_by_postscript_name(&self, postscript_name: &str) -> Result<Handle, SelectionError> {
         self.select_by_postscript_name(postscript_name)
     }
+}
+
+/// Adds a font, but doesn't sort
+fn add_font(handle: Handle, families: &mut Vec<FamilyEntry>) -> Result<(), FontLoadingError> {
+    let font = Font::from_handle(&handle)?;
+    if let Some(postscript_name) = font.postscript_name() {
+        families.push(FamilyEntry {
+            family_name: font.family_name(),
+            postscript_name: postscript_name,
+            font: handle,
+        })
+    }
+    Ok(())
 }
 
 struct FamilyEntry {

--- a/src/sources/mem.rs
+++ b/src/sources/mem.rs
@@ -47,6 +47,25 @@ impl MemSource {
         Ok(MemSource { families })
     }
 
+    /// Add an existing font handle to a `MemSource`.
+    ///
+    /// Note that adding fonts to an existing `MemSource` is slower than creating a new one from a
+    /// `Handle` iterator, since this method sorts after every addition, rather than once at the
+    /// end.
+    pub fn add_font(&mut self, font: Handle) -> Result<(), FontLoadingError> {
+        let font = Font::from_handle(&handle)?;
+        if let Some(postscript_name) = font.postscript_name() {
+            families.push(FamilyEntry {
+                family_name: font.family_name(),
+                postscript_name: postscript_name,
+                font: handle,
+            })
+        }
+        self.families
+            .sort_by(|a, b| a.family_name.cmp(&b.family_name));
+        Ok(())
+    }
+
     /// Returns paths of all fonts installed on the system.
     pub fn all_fonts(&self) -> Result<Vec<Handle>, SelectionError> {
         Ok(self

--- a/src/sources/mem.rs
+++ b/src/sources/mem.rs
@@ -52,10 +52,10 @@ impl MemSource {
     /// Note that adding fonts to an existing `MemSource` is slower than creating a new one from a
     /// `Handle` iterator, since this method sorts after every addition, rather than once at the
     /// end.
-    pub fn add_font(&mut self, font: Handle) -> Result<(), FontLoadingError> {
+    pub fn add_font(&mut self, handle: Handle) -> Result<(), FontLoadingError> {
         let font = Font::from_handle(&handle)?;
         if let Some(postscript_name) = font.postscript_name() {
-            families.push(FamilyEntry {
+            self.families.push(FamilyEntry {
                 family_name: font.family_name(),
                 postscript_name: postscript_name,
                 font: handle,


### PR DESCRIPTION
This PR adds a method that allows a `MemSource` to be extended dynamically after creation. It is useful when implementing an interface that assumes this is possible (for me, the motivating interface is in https://github.com/linebender/piet).