### PR TITLE
Perf select_best_match

### DIFF
--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -160,12 +160,12 @@ fn create_handles_from_core_text_collection(
                 let mut file = if let Ok(file) = File::open(&font_path) {
                     file
                 } else {
-                    break;
+                    continue;
                 };
                 let data = if let Ok(data) = utils::slurp_file(&mut file) {
                     Arc::new(data)
                 } else {
-                    break;
+                    continue;
                 };
                 font_data.insert(font_path.clone(), Arc::clone(&data));
                 data
@@ -177,7 +177,7 @@ fn create_handles_from_core_text_collection(
                         if let Some(font_postscript_name) = font.postscript_name() {
                             if postscript_name == font_postscript_name {
                                 fonts.push(Handle::from_memory(data, font_index));
-                                break 'outer;
+                                continue 'outer;
                             }
                         }
                     }

--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -30,9 +30,9 @@ use crate::loaders::core_text::{self as core_text_loader, FONT_WEIGHT_MAPPING};
 use crate::properties::{Properties, Stretch, Weight};
 use crate::source::Source;
 use crate::utils;
+use std::collections::HashMap;
 use std::fs::File;
 use std::sync::Arc;
-use std::collections::HashMap;
 
 /// A source that contains the installed fonts on macOS.
 #[allow(missing_debug_implementations)]

--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -30,6 +30,8 @@ use crate::loaders::core_text::{self as core_text_loader, FONT_WEIGHT_MAPPING};
 use crate::properties::{Properties, Stretch, Weight};
 use crate::source::Source;
 use crate::utils;
+use std::fs::File;
+use std::sync::Arc;
 
 /// A source that contains the installed fonts on macOS.
 #[allow(missing_debug_implementations)]
@@ -160,18 +162,32 @@ fn create_handle_from_descriptor(descriptor: &CTFontDescriptor) -> Handle {
     let font_path = Path::new(&descriptor.font_path().unwrap()).to_owned();
     if let Ok(FileType::Collection(font_count)) = Font::analyze_path(font_path.clone()) {
         let postscript_name = descriptor.font_name();
+
+        let mut file = if let Ok(file) = File::open(font_path.clone()) {
+            file
+        } else {
+            return Handle::from_path(font_path, 0);
+        };
+
+        let font_data = if let Ok(font_data) = utils::slurp_file(&mut file) {
+            Arc::new(font_data)
+        } else {
+            return Handle::from_path(font_path, 0);
+        };
+
         for font_index in 0..font_count {
-            let font_handle = Handle::from_path(font_path.clone(), font_index);
-            if let Ok(font) = Font::from_handle(&font_handle) {
+            if let Ok(font) = Font::from_bytes(Arc::clone(&font_data), font_index) {
                 if let Some(font_postscript_name) = font.postscript_name() {
                     if postscript_name == font_postscript_name {
-                        return font_handle;
+                        return Handle::from_memory(font_data, font_index);
                     }
                 }
             }
         }
+        Handle::from_memory(font_data, 0)
+    } else {
+        Handle::from_path(font_path, 0)
     }
-    Handle::from_path(font_path, 0)
 }
 
 #[cfg(test)]

--- a/tests/select_font.rs
+++ b/tests/select_font.rs
@@ -33,7 +33,16 @@ macro_rules! match_handle {
                     font_index, $index
                 );
             }
-            _ => unreachable!(),
+            Handle::Memory {
+                bytes: _,
+                font_index,
+            } => {
+                assert_eq!(
+                    font_index, $index,
+                    "expecting font index {} not {}",
+                    font_index, $index
+                );
+            }
         }
     };
 }


### PR DESCRIPTION
When `create_handles_from_core_text_collection`, we only need to read the same path file once, and change handle to memory mode, so when load font from the handle next time, we can use the memory data.

before:
<img width="941" alt="截屏2020-11-18 下午12 19 34" src="https://user-images.githubusercontent.com/11287532/99483216-bdbd4e00-2998-11eb-92ee-5cc9e6987fb5.png">
after:
<img width="927" alt="截屏2020-11-19 下午8 41 29" src="https://user-images.githubusercontent.com/11287532/99667839-ec761a00-2aa7-11eb-99ea-481799b7b32f.png">
