### PR TITLE
Allow getting individual sources from a `MultiSource`.

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -18,6 +18,7 @@ use crate::font::Font;
 use crate::handle::Handle;
 use crate::matching;
 use crate::properties::Properties;
+use std::any::Any;
 
 #[cfg(all(
     any(target_os = "macos", target_os = "ios"),
@@ -68,7 +69,7 @@ const DEFAULT_FONT_FAMILY_FANTASY: &'static str = "fantasy";
 /// A database of installed fonts that can be queried.
 ///
 /// This trait is object-safe.
-pub trait Source {
+pub trait Source: Any {
     /// Returns paths of all fonts installed on the system.
     fn all_fonts(&self) -> Result<Vec<Handle>, SelectionError>;
 

--- a/src/sources/multi.rs
+++ b/src/sources/multi.rs
@@ -19,7 +19,7 @@ use crate::family_name::FamilyName;
 use crate::handle::Handle;
 use crate::properties::Properties;
 use crate::source::Source;
-use std::ops::Index;
+use std::ops::{Index, IndexMut};
 
 /// A source that encapsulates multiple sources and allows them to be queried as a group.
 ///
@@ -120,5 +120,11 @@ impl Index<usize> for MultiSource {
 
     fn index(&self, idx: usize) -> &Self::Output {
         &*self.subsources[idx]
+    }
+}
+
+impl IndexMut<usize> for MultiSource {
+    fn index_mut(&mut self, idx: usize) -> &mut Self::Output {
+        &mut *self.subsources[idx]
     }
 }

--- a/src/sources/multi.rs
+++ b/src/sources/multi.rs
@@ -19,6 +19,7 @@ use crate::family_name::FamilyName;
 use crate::handle::Handle;
 use crate::properties::Properties;
 use crate::source::Source;
+use std::ops::Index;
 
 /// A source that encapsulates multiple sources and allows them to be queried as a group.
 ///
@@ -111,5 +112,13 @@ impl Source for MultiSource {
     #[inline]
     fn select_by_postscript_name(&self, postscript_name: &str) -> Result<Handle, SelectionError> {
         self.select_by_postscript_name(postscript_name)
+    }
+}
+
+impl Index<usize> for MultiSource {
+    type Output = dyn Source;
+
+    fn index(&self, idx: usize) -> &Self::Output {
+        &*self.subsources[idx]
     }
 }


### PR DESCRIPTION
This PR has 2 parts

 1. Make `Source` inherit `Any` to allow downcasting.
 2. Allow getting access to `Source`s in a `MultiSource`.

These things together allow access to the constituent sources in a multisource, for example to allow adding to a `MemSource`.