### PR TITLE
Add `iter` to `MultiSource`, and `as_any` to `Source`

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -151,4 +151,10 @@ pub trait Source: Any {
         }
         Ok(fields)
     }
+
+    /// Accesses this `Source` as `Any`, which allows downcasting back to a concrete type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Accesses this `Source` as `Any`, which allows downcasting back to a concrete type.
+    fn as_mut_any(&mut self) -> &mut dyn Any;
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -152,9 +152,11 @@ pub trait Source: Any {
         Ok(fields)
     }
 
-    /// Accesses this `Source` as `Any`, which allows downcasting back to a concrete type.
+    /// Accesses this `Source` as `Any`, which allows downcasting back to a concrete type from a
+    /// trait object.
     fn as_any(&self) -> &dyn Any;
 
-    /// Accesses this `Source` as `Any`, which allows downcasting back to a concrete type.
+    /// Accesses this `Source` as `Any`, which allows downcasting back to a concrete type from a
+    /// trait object.
     fn as_mut_any(&mut self) -> &mut dyn Any;
 }

--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -17,8 +17,12 @@ use core_foundation::string::CFString;
 use core_text::font_collection::{self, CTFontCollection};
 use core_text::font_descriptor::{self, CTFontDescriptor};
 use core_text::font_manager;
+use std::any::Any;
+use std::collections::HashMap;
 use std::f32;
+use std::fs::File;
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::error::SelectionError;
 use crate::family_handle::FamilyHandle;
@@ -30,9 +34,6 @@ use crate::loaders::core_text::{self as core_text_loader, FONT_WEIGHT_MAPPING};
 use crate::properties::{Properties, Stretch, Weight};
 use crate::source::Source;
 use crate::utils;
-use std::collections::HashMap;
-use std::fs::File;
-use std::sync::Arc;
 
 /// A source that contains the installed fonts on macOS.
 #[allow(missing_debug_implementations)]
@@ -125,6 +126,16 @@ impl Source for CoreTextSource {
 
     fn select_by_postscript_name(&self, postscript_name: &str) -> Result<Handle, SelectionError> {
         self.select_by_postscript_name(postscript_name)
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline]
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/src/sources/directwrite.rs
+++ b/src/sources/directwrite.rs
@@ -12,6 +12,7 @@
 
 use dwrote::Font as DWriteFont;
 use dwrote::FontCollection as DWriteFontCollection;
+use std::any::Any;
 
 use crate::error::SelectionError;
 use crate::family_handle::FamilyHandle;
@@ -122,5 +123,15 @@ impl Source for DirectWriteSource {
     #[inline]
     fn select_family_by_name(&self, family_name: &str) -> Result<FamilyHandle, SelectionError> {
         self.select_family_by_name(family_name)
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline]
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
     }
 }

--- a/src/sources/fontconfig.rs
+++ b/src/sources/fontconfig.rs
@@ -21,6 +21,7 @@ use crate::family_name::FamilyName;
 use crate::handle::Handle;
 use crate::properties::Properties;
 use crate::source::Source;
+use std::any::Any;
 
 /// A source that contains the fonts installed on the system, as reported by the Fontconfig
 /// library.
@@ -226,6 +227,16 @@ impl Source for FontconfigSource {
     #[inline]
     fn select_by_postscript_name(&self, postscript_name: &str) -> Result<Handle, SelectionError> {
         self.select_by_postscript_name(postscript_name)
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline]
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -14,6 +14,7 @@
 //!
 //! This is the native source on Android.
 
+use std::any::Any;
 use std::fs::File;
 use std::path::PathBuf;
 use walkdir::WalkDir;
@@ -140,6 +141,16 @@ impl Source for FsSource {
 
     fn select_by_postscript_name(&self, postscript_name: &str) -> Result<Handle, SelectionError> {
         self.select_by_postscript_name(postscript_name)
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline]
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/src/sources/mem.rs
+++ b/src/sources/mem.rs
@@ -48,14 +48,16 @@ impl MemSource {
 
     /// Add an existing font handle to a `MemSource`.
     ///
+    /// Returns the font that was just added.
+    ///
     /// Note that adding fonts to an existing `MemSource` is slower than creating a new one from a
     /// `Handle` iterator, since this method sorts after every addition, rather than once at the
     /// end.
-    pub fn add_font(&mut self, handle: Handle) -> Result<(), FontLoadingError> {
-        add_font(handle, &mut self.families)?;
+    pub fn add_font(&mut self, handle: Handle) -> Result<Font, FontLoadingError> {
+        let font = add_font(handle, &mut self.families)?;
         self.families
             .sort_by(|a, b| a.family_name.cmp(&b.family_name));
-        Ok(())
+        Ok(font)
     }
 
     /// Add a number of existing font handles to a `MemSource`.
@@ -183,8 +185,8 @@ impl Source for MemSource {
     }
 }
 
-/// Adds a font, but doesn't sort
-fn add_font(handle: Handle, families: &mut Vec<FamilyEntry>) -> Result<(), FontLoadingError> {
+/// Adds a font, but doesn't sort. Returns the font that was created to check for validity.
+fn add_font(handle: Handle, families: &mut Vec<FamilyEntry>) -> Result<Font, FontLoadingError> {
     let font = Font::from_handle(&handle)?;
     if let Some(postscript_name) = font.postscript_name() {
         families.push(FamilyEntry {
@@ -193,7 +195,7 @@ fn add_font(handle: Handle, families: &mut Vec<FamilyEntry>) -> Result<(), FontL
             font: handle,
         })
     }
-    Ok(())
+    Ok(font)
 }
 
 struct FamilyEntry {

--- a/src/sources/mem.rs
+++ b/src/sources/mem.rs
@@ -17,6 +17,7 @@ use crate::font::Font;
 use crate::handle::Handle;
 use crate::properties::Properties;
 use crate::source::Source;
+use std::any::Any;
 
 /// A source that keeps fonts in memory.
 #[allow(missing_debug_implementations)]
@@ -164,6 +165,16 @@ impl Source for MemSource {
 
     fn select_by_postscript_name(&self, postscript_name: &str) -> Result<Handle, SelectionError> {
         self.select_by_postscript_name(postscript_name)
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline]
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
     }
 }
 

--- a/src/sources/mem.rs
+++ b/src/sources/mem.rs
@@ -26,6 +26,11 @@ pub struct MemSource {
 }
 
 impl MemSource {
+    /// Creates a new empty memory source.
+    pub fn empty() -> MemSource {
+        MemSource { families: vec![] }
+    }
+
     /// Creates a new memory source that contains the given set of font handles.
     ///
     /// The fonts referenced by the handles are eagerly loaded into memory.


### PR DESCRIPTION
The `iter`/`iter_mut` methods allow iterating through the subsources of a `MultiSource`. The `as_any`/`as_mut_any` methods are necessary for downcasting `Source`s into concrete types.

In addition, the `find_source` and `find_source_mut` methods are added as a convenience to find the first source matching the given type.