### PR TITLE
Replace dirs with dirs-next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ freetype = "0.7"
 servo-fontconfig = "0.5"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android")))'.dependencies]
-dirs = "2.0"
+dirs-next = "2.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 walkdir = "2.1"

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use walkdir::WalkDir;
 
 #[cfg(not(any(target_os = "android", target_family = "windows")))]
-use dirs;
+use dirs_next;
 #[cfg(target_family = "windows")]
 use std::ffi::OsString;
 #[cfg(target_family = "windows")]
@@ -180,7 +180,7 @@ fn default_font_directories() -> Vec<PathBuf> {
         PathBuf::from("/Library/Fonts"),
         PathBuf::from("/Network/Library/Fonts"),
     ];
-    if let Some(mut path) = dirs::home_dir() {
+    if let Some(mut path) = dirs_next::home_dir() {
         path.push("Library");
         path.push("Fonts");
         directories.push(path);
@@ -196,11 +196,11 @@ fn default_font_directories() -> Vec<PathBuf> {
         PathBuf::from("/var/run/host/usr/share/fonts"), // Flatpak specific
         PathBuf::from("/var/run/host/usr/local/share/fonts"),
     ];
-    if let Some(path) = dirs::home_dir() {
+    if let Some(path) = dirs_next::home_dir() {
         directories.push(path.join(".fonts")); // ~/.fonts is deprecated
         directories.push(path.join("local").join("share").join("fonts")); // Flatpak specific
     }
-    if let Some(mut path) = dirs::data_dir() {
+    if let Some(mut path) = dirs_next::data_dir() {
         path.push("fonts");
         directories.push(path);
     }


### PR DESCRIPTION
This pull request replaces the `dirs` dependency with the `dirs-next` crate in accordance with [this Rust security advisory](https://rustsec.org/advisories/RUSTSEC-2020-0053). Closes #173.

This is my first time contributing to font-kit. Let me know if you need me to do anything else.