### PR TITLE
Changed examples/render-glyph to handle multi-byte characters

### DIFF
--- a/examples/render-glyph.rs
+++ b/examples/render-glyph.rs
@@ -85,7 +85,7 @@ fn main() {
     let matches = get_args();
 
     let postscript_name = matches.value_of("POSTSCRIPT-NAME").unwrap();
-    let character = matches.value_of("GLYPH").unwrap().as_bytes()[0] as char;
+    let character = matches.value_of("GLYPH").unwrap().chars().next().unwrap();
     let size: f32 = matches.value_of("SIZE").unwrap().parse().unwrap();
 
     let (canvas_format, rasterization_options) = if matches.is_present("bilevel") {


### PR DESCRIPTION
Before this change, a garbage glyph would be rendered if a multi-byte character was used as input on the command line. Now it will render properly if the selected font supports the corresponding glyph.

Ex:
`ArialMT ä` works.
`ArialMT 心` doesn't work because Arial doesn't have the glyph.
`SimSun 心` works.

