### PR TITLE
Fix panic when parsing invalid `usWidthClass`

### DIFF
--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -359,14 +359,14 @@ impl Font {
                 _ => Style::Normal,
             };
             let stretch = match os2_table {
-                Some(os2_table) if (*os2_table).usWidthClass > 0 => {
+                Some(os2_table) if (1..=9).contains(&(*os2_table).usWidthClass) => {
                     Stretch(Stretch::MAPPING[((*os2_table).usWidthClass as usize) - 1])
                 }
                 _ => Stretch::NORMAL,
             };
             let weight = match os2_table {
                 None => Weight::NORMAL,
-                Some(os2_table) => Weight((*os2_table).usWeightClass as u32 as f32),
+                Some(os2_table) => Weight((*os2_table).usWeightClass as f32),
             };
             Properties {
                 style,


### PR DESCRIPTION
The code here just trusted the value to always to be valid, but since this may be an arbitrary font, the value may not always be valid. In my case the `usWidthClass` I'm seeing has the value 500, probably the `usWeightClass` accidentally being assigned to the `usWidthClass`.