### PR TITLE
switch to yeslogic-fontconfig-sys instead of servo-fontconfig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT/Apache-2.0"
@@ -14,7 +14,8 @@ edition = "2018"
 default = ["source"]
 loader-freetype = ["freetype"]
 loader-freetype-default = ["loader-freetype"]
-source-fontconfig = ["servo-fontconfig"]
+source-fontconfig = ["yeslogic-fontconfig-sys"]
+source-fontconfig-dlopen = ["yeslogic-fontconfig-sys/dlopen"]
 source-fontconfig-default = ["source-fontconfig"]
 source = []
 
@@ -32,8 +33,8 @@ pathfinder_simd = "0.5.1"
 version = "0.7"
 optional = true
 
-[dependencies.servo-fontconfig]
-version = "0.5"
+[dependencies.yeslogic-fontconfig-sys]
+version = "3.0.0"
 optional = true
 
 [dev-dependencies]
@@ -58,7 +59,7 @@ core-text = "19.1.0"
 freetype = "0.7"
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
-servo-fontconfig = "0.5"
+yeslogic-fontconfig-sys = "3.0.0"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android")))'.dependencies]
 dirs-next = "2.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=RUST_FONTCONFIG_DLOPEN");
+    let dlopen = std::env::var("RUST_FONTCONFIG_DLOPEN").is_ok();
+    if dlopen {
+        println!("cargo:rustc-cfg=feature=\"source-fontconfig-dlopen\"");
+    }
+}

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -1198,7 +1198,7 @@ impl FtFixedToF32 for RectI {
     type Output = RectF;
     #[inline]
     fn ft_fixed_26_6_to_f32(self) -> RectF {
-        (self.to_f32() * (1.0 / 64.0))
+        self.to_f32() * (1.0 / 64.0)
     }
 }
 


### PR DESCRIPTION
servo-fontconfig statically links a vendored fontconfig library if fontconfig is not found by pkgconfig. Using a vendored fontconfig
library instead of the system fontconfig library doesn't actually work well though:
https://github.com/slint-ui/slint/issues/88
Building a vendored copy of fontconfig is also problematic because fontconfig has a lot of C dependencies, which makes it difficult to cross compile the vendored copy of fontconfig:

```
$ pkg-config fontconfig --static --libs
-lfontconfig -lfreetype -lz -lbz2 -lpng16 -lm -lm -lz -lharfbuzz -lm -lglib-2.0 -lm -lpcre -lsysprof-capture-4 -pthread -lgraphite2 -lbrotlidec -lbrotlicommon -lxml2 -lz -llzma -lm
```

Instead of using a vendored copy, with
https://github.com/yeslogic/fontconfig-rs/pull/12
yeslogic-fontconfig-sys will have a Cargo feature to dlopen fontconfig at runtime instead of linking it at build time. This is exposed in font-kit with the new source-fontconfig-dlopen feature, which is disabled by default. This feature makes it considerably easier to cross compile by avoiding the need to cross compile fontconfig and all its dependencies.
