### PR TITLE
fix compilation errors in tests

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -264,6 +264,7 @@ pub fn get_vertically_hinted_glyph_outline() {
 
 #[cfg(all(
     feature = "source",
+    not(feature = "loader-freetype-default"),
     not(any(target_os = "macos", target_os = "ios", target_family = "windows"))
 ))]
 #[test]
@@ -354,6 +355,7 @@ pub fn get_fully_hinted_glyph_outline() {
 
 #[cfg(all(
     feature = "source",
+    not(feature = "loader-freetype-default"),
     not(any(target_os = "macos", target_os = "ios", target_family = "windows"))
 ))]
 #[test]


### PR DESCRIPTION
With this command line:

```
cargo test --features="source,loader-freetype-default"
```

Then these errors are produced:

```
error[E0428]: the name `get_vertically_hinted_glyph_outline` is defined multiple times
   --> tests/tests.rs:270:1
    |
226 | pub fn get_vertically_hinted_glyph_outline() {
    | -------------------------------------------- previous definition of the value `get_vertically_hinted_glyph_outline` here
...
270 | pub fn get_vertically_hinted_glyph_outline() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `get_vertically_hinted_glyph_outline` redefined here
    |
    = note: `get_vertically_hinted_glyph_outline` must be defined only once in the value namespace of this module

error[E0428]: the name `get_fully_hinted_glyph_outline` is defined multiple times
   --> tests/tests.rs:360:1
    |
316 | pub fn get_fully_hinted_glyph_outline() {
    | --------------------------------------- previous definition of the value `get_fully_hinted_glyph_outline` here
...
360 | pub fn get_fully_hinted_glyph_outline() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `get_fully_hinted_glyph_outline` redefined here
    |
    = note: `get_fully_hinted_glyph_outline` must be defined only once in the value namespace of this module
```

This PR fixes those by adding a conditional config, so that the two compiles are exclusive to each other.