### PR TITLE
Bail out from rendering when bitmap_buffer is null

### DIFF
--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -844,6 +844,13 @@ impl Font {
             let bitmap_size = Vector2I::new(bitmap_width, bitmap_height);
             let bitmap_buffer = (*bitmap).buffer as *const i8 as *const u8;
             let bitmap_length = bitmap_stride * bitmap_height as usize;
+            if bitmap_buffer.is_null() {
+                assert_eq!(
+                    bitmap_length, 0,
+                    "bitmap length should be 0 when bitmap_buffer is nullptr"
+                );
+                return Ok(());
+            }
             let buffer = slice::from_raw_parts(bitmap_buffer, bitmap_length);
             let dst_point = Vector2I::new(
                 (*(*self.freetype_face).glyph).bitmap_left,


### PR DESCRIPTION
I don't really understand what's going on here. All I really know is that I ran into one of the standard library's debug assertions when running some of the examples in `plotters`. I trimmed one down, but not a whole lot.

```rust
use plotters::prelude::*;
fn main() {
    let mut buffer = vec![0u8; 1024 * 768 * 3];
    let area = BitMapBackend::with_buffer(&mut buffer[..], (1024, 768))
        .into_drawing_area()
        .split_evenly((1, 2));
    let _chart = ChartBuilder::on(&area[0])
        .caption("Incremental Example", ("sans-serif", 20))
        .build_cartesian_2d(0..10, 0..10)
        .expect("Unable to build ChartContext");
}
```
Running this example without this patch using `cargo +nightly run -Zbuild-std --target=x86_64-unknown-linux-gnu` will panic:
```
thread 'main' panicked at 'unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`', /home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panicking.rs:126:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread caused non-unwinding panic. aborting.
Aborted (core dumped)
```
The problem is that the pointer is null.