### PR TITLE
Derive Hash for `FamilyName` and `Style`

### DIFF
--- a/src/family_name.rs
+++ b/src/family_name.rs
@@ -16,7 +16,7 @@
 /// https://drafts.csswg.org/css-fonts-3/#font-family-prop.
 ///
 /// TODO(pcwalton): `system-ui`, `emoji`, `math`, `fangsong`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Hash)]
 pub enum FamilyName {
     /// A specific font family, specified by name: e.g. "Arial", "times".
     Title(String),

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -62,7 +62,7 @@ impl Properties {
 }
 
 /// Allows italic or oblique faces to be selected.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Hash)]
 pub enum Style {
     /// A face that is neither italic not obliqued.
     Normal,


### PR DESCRIPTION
I needed this for caching implementation and felt it easier to use font-kit's types instead of converting them into my own.