### PR TITLE
Update to version 0.13 in preparation for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
A new release is needed to get https://github.com/servo/font-kit/issues/224 out the door