### PR TITLE
CoreText: Faster OTC font loading

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,5 +144,5 @@ pub mod source;
 #[cfg(feature = "source")]
 pub mod sources;
 
-mod matching;
+pub mod matching;
 mod utils;

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -61,6 +61,7 @@ const OPENTYPE_TABLE_TAG_HEAD: u32 = 0x68656164;
 
 /// DirectWrite's representation of a font.
 #[allow(missing_debug_implementations)]
+#[derive(Clone)]
 pub struct NativeFont {
     /// The native DirectWrite font object.
     pub dwrite_font: DWriteFont,
@@ -160,7 +161,8 @@ impl Font {
 
     /// Creates a font from a native API handle.
     #[inline]
-    pub unsafe fn from_native_font(native_font: NativeFont) -> Font {
+    pub unsafe fn from_native_font(native_font: &NativeFont) -> Font {
+        let native_font = native_font.clone();
         Font {
             dwrite_font: native_font.dwrite_font,
             dwrite_font_face: native_font.dwrite_font_face,
@@ -747,7 +749,7 @@ impl Loader for Font {
     }
 
     #[inline]
-    unsafe fn from_native_font(native_font: Self::NativeFont) -> Self {
+    unsafe fn from_native_font(native_font: &Self::NativeFont) -> Self {
         Font::from_native_font(native_font)
     }
 

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -197,9 +197,10 @@ impl Font {
     }
 
     /// Creates a font from a native API handle.
-    pub unsafe fn from_native_font(freetype_face: NativeFont) -> Font {
+    pub unsafe fn from_native_font(freetype_face: &NativeFont) -> Font {
         // We make an in-memory copy of the underlying font data. This is because the native font
         // does not necessarily hold a strong reference to the memory backing it.
+        let freetype_face = *freetype_face;
         const CHUNK_SIZE: usize = 4096;
         let mut font_data = vec![];
         loop {
@@ -1036,7 +1037,7 @@ impl Loader for Font {
     }
 
     #[inline]
-    unsafe fn from_native_font(native_font: Self::NativeFont) -> Self {
+    unsafe fn from_native_font(native_font: &Self::NativeFont) -> Self {
         Font::from_native_font(native_font)
     }
 

--- a/tests/select_font.rs
+++ b/tests/select_font.rs
@@ -44,6 +44,7 @@ macro_rules! match_handle {
                     font_index, $index
                 );
             }
+            Handle::Native { .. } => {}
         }
     };
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -624,18 +624,6 @@ pub fn get_font_properties() {
 
 #[cfg(feature = "source")]
 #[test]
-pub fn get_font_data() {
-    let font = SystemSource::new()
-        .select_best_match(&[FamilyName::SansSerif], &Properties::new())
-        .unwrap()
-        .load()
-        .unwrap();
-    let data = font.copy_font_data().unwrap();
-    debug_assert!(SFNT_VERSIONS.iter().any(|version| data[0..4] == *version));
-}
-
-#[cfg(feature = "source")]
-#[test]
 pub fn load_font_table() {
     let font = SystemSource::new()
         .select_best_match(&[FamilyName::SansSerif], &Properties::new())


### PR DESCRIPTION
Background: At [Zed](https://zed.dev) we've had users report that certain fonts could take a long time to load (https://github.com/zed-industries/community/issues/1745). Admittedly these font files are quite big (Iosevka font weights like 300Mb), but I've still went looking and found out that font-kit might sometimes copy excessive amount of memory, as seen in the flamegraph of loading of Iosevka:
![image](https://github.com/servo/font-kit/assets/24362066/7c291252-7814-4731-9340-b4e1121dd662)

This commit does several things:
- It uses native API to handle OTC via font descriptors. This gets rid of most of memmoves/memcopies
- It permits storing an already loaded font in Handle to avoid loading it in `load` again.
- It exposes `matching` module in public interface of a crate so that users don't have to go through Source::select_best_match`.

Note that I've pulled this commit verbatim from how we're using it in Zed; I made sure tests pass on Windows/Linux CI, but I didn't test it there (as we're only available on Mac for now). The macOS part works fine on production for few days already.

Another reason to have that commit (I guess) is that it vastly improves throughput of examples like `list-fonts` and `match-font` (https://github.com/servo/font-kit/issues/209). The particular command-line that this user was using runs 10x faster for me with this commit (0.15s vs 1.1s on M1 Max). `list-fonts` completes in ~2s on debug build (vs not completing within 10s or so on current master).