### PR TITLE
Add support for OpenHarmony

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,10 @@ core-text = "20.1.0"
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 freetype = "0.7"
 
-[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32")))'.dependencies]
+[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32", target_env = "ohos")))'.dependencies]
 yeslogic-fontconfig-sys = "5.0"
 
-[target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android")))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android", target_env = "ohos")))'.dependencies]
 dirs-next = "2.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //!   API to query and match fonts.
 //!
 //! * Filesystem (cross-platform): A simple source that reads fonts from a path on disk. This is
-//!   the default on Android.
+//!   the default on Android and OpenHarmony.
 //!
 //! * Memory (cross-platform): A source that reads from a fixed set of fonts in memory.
 //!

--- a/src/source.rs
+++ b/src/source.rs
@@ -52,8 +52,12 @@ pub use crate::sources::fs::FsSource as SystemSource;
 const DEFAULT_FONT_FAMILY_SERIF: &'static str = "Times New Roman";
 #[cfg(any(target_family = "windows", target_os = "macos", target_os = "ios"))]
 const DEFAULT_FONT_FAMILY_SANS_SERIF: &'static str = "Arial";
+#[cfg(target_env = "ohos")]
+const DEFAULT_FONT_FAMILY_SANS_SERIF: &str = "HarmonyOS Sans";
 #[cfg(any(target_family = "windows", target_os = "macos", target_os = "ios"))]
 const DEFAULT_FONT_FAMILY_MONOSPACE: &'static str = "Courier New";
+#[cfg(target_env = "ohos")]
+const DEFAULT_FONT_FAMILY_MONOSPACE: &str = "HarmonyOS Sans";
 #[cfg(any(target_family = "windows", target_os = "macos", target_os = "ios"))]
 const DEFAULT_FONT_FAMILY_CURSIVE: &'static str = "Comic Sans MS";
 #[cfg(target_family = "windows")]
@@ -63,9 +67,19 @@ const DEFAULT_FONT_FAMILY_FANTASY: &'static str = "Papyrus";
 
 #[cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))]
 const DEFAULT_FONT_FAMILY_SERIF: &str = "serif";
-#[cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(
+    target_family = "windows",
+    target_os = "macos",
+    target_os = "ios",
+    target_env = "ohos"
+)))]
 const DEFAULT_FONT_FAMILY_SANS_SERIF: &str = "sans-serif";
-#[cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(
+    target_family = "windows",
+    target_os = "macos",
+    target_os = "ios",
+    target_env = "ohos"
+)))]
 const DEFAULT_FONT_FAMILY_MONOSPACE: &str = "monospace";
 #[cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))]
 const DEFAULT_FONT_FAMILY_CURSIVE: &str = "cursive";

--- a/src/source.rs
+++ b/src/source.rs
@@ -27,18 +27,24 @@ use std::any::Any;
 pub use crate::sources::core_text::CoreTextSource as SystemSource;
 #[cfg(all(target_family = "windows", not(feature = "source-fontconfig-default")))]
 pub use crate::sources::directwrite::DirectWriteSource as SystemSource;
-#[cfg(any(
-    not(any(
-        target_os = "android",
-        target_os = "macos",
-        target_os = "ios",
-        target_family = "windows",
-        target_arch = "wasm32"
-    )),
-    feature = "source-fontconfig-default"
+#[cfg(all(
+    any(
+        not(any(
+            target_os = "android",
+            target_os = "macos",
+            target_os = "ios",
+            target_family = "windows",
+            target_arch = "wasm32",
+        )),
+        feature = "source-fontconfig-default"
+    ),
+    not(target_env = "ohos")
 ))]
 pub use crate::sources::fontconfig::FontconfigSource as SystemSource;
 #[cfg(all(target_os = "android", not(feature = "source-fontconfig-default")))]
+pub use crate::sources::fs::FsSource as SystemSource;
+
+#[cfg(target_env = "ohos")]
 pub use crate::sources::fs::FsSource as SystemSource;
 
 // FIXME(pcwalton): These could expand to multiple fonts, and they could be language-specific.

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -12,14 +12,14 @@
 //!
 //! This source uses the WalkDir abstraction from the `walkdir` crate to locate fonts.
 //!
-//! This is the native source on Android.
+//! This is the native source on Android and OpenHarmony.
 
 use std::any::Any;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
-#[cfg(not(any(target_os = "android", target_family = "windows")))]
+#[cfg(not(any(target_os = "android", target_family = "windows", target_env = "ohos")))]
 use dirs_next;
 #[cfg(target_family = "windows")]
 use std::ffi::OsString;
@@ -44,7 +44,7 @@ use crate::sources::mem::MemSource;
 ///
 /// This source uses the WalkDir abstraction from the `walkdir` crate to locate fonts.
 ///
-/// This is the native source on Android.
+/// This is the native source on Android and OpenHarmony.
 #[allow(missing_debug_implementations)]
 pub struct FsSource {
     mem_source: MemSource,
@@ -59,9 +59,9 @@ impl Default for FsSource {
 impl FsSource {
     /// Opens the default set of directories on this platform and indexes the fonts found within.
     ///
-    /// Do not rely on this function for systems other than Android. It makes a best effort to
-    /// locate fonts in the typical platform directories, but it is too simple to pick up fonts
-    /// that are stored in unusual locations but nevertheless properly installed.
+    /// Do not rely on this function for systems other than Android or OpenHarmony. It makes a best
+    /// effort to locate fonts in the typical platform directories, but it is too simple to pick up
+    /// fonts that are stored in unusual locations but nevertheless properly installed.
     pub fn new() -> FsSource {
         let mut fonts = vec![];
         for font_directory in default_font_directories() {
@@ -177,7 +177,7 @@ impl Source for FsSource {
     }
 }
 
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "android", target_env = "ohos"))]
 fn default_font_directories() -> Vec<PathBuf> {
     vec![PathBuf::from("/system/fonts")]
 }
@@ -211,7 +211,12 @@ fn default_font_directories() -> Vec<PathBuf> {
     directories
 }
 
-#[cfg(not(any(target_os = "android", target_family = "windows", target_os = "macos")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_family = "windows",
+    target_os = "macos",
+    target_env = "ohos"
+)))]
 fn default_font_directories() -> Vec<PathBuf> {
     let mut directories = vec![
         PathBuf::from("/usr/share/fonts"),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -25,7 +25,8 @@ pub mod directwrite;
         target_os = "macos",
         target_os = "ios",
         target_family = "windows",
-        target_arch = "wasm32"
+        target_arch = "wasm32",
+        target_env = "ohos",
     )),
     feature = "source-fontconfig"
 ))]


### PR DESCRIPTION
- Use the filesystem as SystemSource on OpenHarmony
- Use [HarmonyOS Sans] as the default font family for available styles on Openharmony

[HarmonyOS Sans], which despite the name is also available in [OpenHarmony](https://gitee.com/openharmony/utils_system_resources), is really the default and only font on OpenHarmony besides some language specific NotoSans fonts.

[HarmonyOS Sans]: https://developer.huawei.com/consumer/en/doc/design-guides-V1/font-0000001157868583-V1

~~Note: So far I've only tested on a HarmonyOS phone, but since HarmonyOS Sans is also published on Gitee as part of OpenHarmony it should also be available on OpenHarmony devices. Nevertheless, I'm marking this MR as a Draft, until I've confirmed that the HarmonyOS fonts are also available on pure OpenHarmony devices.~~
Edit: The colleagues from Oniro have tested and confirmed, that the `HarmonyOS Sans`  fonts are also available on pure OpenHarmony devices.