### PR TITLE
Fix fontkit CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,11 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Install
         run: |
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections;
@@ -42,17 +38,13 @@ jobs:
 
   ci-macos:
     name: macOS
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build
       - name: Tests
@@ -60,17 +52,13 @@ jobs:
 
   ci-win:
     name: Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build
       - name: Tests

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -463,6 +463,9 @@ impl Font {
             }
 
             let outline = &(*(*self.freetype_face).glyph).outline;
+            if outline.n_contours == 0 {
+                return Ok(());
+            }
             let contours = slice::from_raw_parts(outline.contours, outline.n_contours as usize);
             let point_positions = slice::from_raw_parts(outline.points, outline.n_points as usize);
             let point_tags = slice::from_raw_parts(outline.tags, outline.n_points as usize);


### PR DESCRIPTION
- Update GH actions, to fix warnings that the actions are using too old node versions
- Fix a Safety precondition violation in freetype.rs (exposed by Rust 1.78 debug assertions in the std library).