### PR TITLE
Fix cargo doc warning

### DIFF
--- a/src/family_name.rs
+++ b/src/family_name.rs
@@ -13,7 +13,7 @@
 /// A possible value for the `font-family` CSS property.
 ///
 /// These descriptions are taken from CSS Fonts Level 3 § 3.1:
-/// https://drafts.csswg.org/css-fonts-3/#font-family-prop.
+/// <https://drafts.csswg.org/css-fonts-3/#font-family-prop>.
 ///
 /// TODO(pcwalton): `system-ui`, `emoji`, `math`, `fangsong`
 #[derive(Clone, Debug, PartialEq, Hash)]

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -11,7 +11,7 @@
 //! Properties that specify which font in a family to use: e.g. style, weight, and stretchiness.
 //!
 //! Much of the documentation in this modules comes from the CSS 3 Fonts specification:
-//! https://drafts.csswg.org/css-fonts-3/
+//! <https://drafts.csswg.org/css-fonts-3/>
 
 use std::fmt::{self, Debug, Display, Formatter};
 


### PR DESCRIPTION
Fix "this URL is not a hyperlink" warning