### PR TITLE
Use font-config-sys 6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.13.2"
+version = "0.14.0"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT OR Apache-2.0"
@@ -9,6 +9,7 @@ repository = "https://github.com/servo/font-kit"
 homepage = "https://github.com/servo/font-kit"
 exclude = ["resources/**"]
 edition = "2018"
+rust-version = "1.77"
 
 [features]
 default = ["source"]
@@ -34,7 +35,7 @@ version = "0.7"
 optional = true
 
 [dependencies.yeslogic-fontconfig-sys]
-version = "5.0"
+version = "6.0"
 optional = true
 
 [dev-dependencies]
@@ -59,7 +60,7 @@ core-text = "20.1.0"
 freetype-sys = "0.20"
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32", target_env = "ohos")))'.dependencies]
-yeslogic-fontconfig-sys = "5.0"
+yeslogic-fontconfig-sys = "6.0"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android", target_env = "ohos")))'.dependencies]
 dirs-next = "2.0"


### PR DESCRIPTION
c.f. https://github.com/yeslogic/fontconfig-rs/pull/40

crate `cstr` is now unmaintained. It hasnt been added to advisory-db yet.