### PR TITLE
Switch from `dirs-next` to `dirs` and release a new version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-kit"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Patrick Walton <pcwalton@mimiga.net>"]
 description = "A cross-platform font loading library"
 license = "MIT OR Apache-2.0"
@@ -63,7 +63,7 @@ freetype-sys = "0.20"
 yeslogic-fontconfig-sys = "6.0"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android", target_env = "ohos")))'.dependencies]
-dirs-next = "2.0"
+dirs = "5.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 walkdir = "2.1"

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 #[cfg(not(any(target_os = "android", target_family = "windows", target_env = "ohos")))]
-use dirs_next;
+use dirs;
 #[cfg(target_family = "windows")]
 use std::ffi::OsString;
 #[cfg(target_family = "windows")]
@@ -203,7 +203,7 @@ fn default_font_directories() -> Vec<PathBuf> {
         PathBuf::from("/Library/Fonts"),
         PathBuf::from("/Network/Library/Fonts"),
     ];
-    if let Some(mut path) = dirs_next::home_dir() {
+    if let Some(mut path) = dirs::home_dir() {
         path.push("Library");
         path.push("Fonts");
         directories.push(path);
@@ -224,11 +224,11 @@ fn default_font_directories() -> Vec<PathBuf> {
         PathBuf::from("/var/run/host/usr/share/fonts"), // Flatpak specific
         PathBuf::from("/var/run/host/usr/local/share/fonts"),
     ];
-    if let Some(path) = dirs_next::home_dir() {
+    if let Some(path) = dirs::home_dir() {
         directories.push(path.join(".fonts")); // ~/.fonts is deprecated
         directories.push(path.join("local").join("share").join("fonts")); // Flatpak specific
     }
-    if let Some(mut path) = dirs_next::data_dir() {
+    if let Some(mut path) = dirs::data_dir() {
         path.push("fonts");
         directories.push(path);
     }


### PR DESCRIPTION
`dirs-next` is now the abandoned crate, so switch to `dirs`.
