### PR TITLE
Bump `pathfinder_simd` to latest (0.5.4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lazy_static = "1.1"
 libc = "0.2"
 log = "0.4.4"
 pathfinder_geometry = "0.5"
-pathfinder_simd = "0.5.3"
+pathfinder_simd = "0.5.4"
 
 [dependencies.freetype]
 version = "0.7"


### PR DESCRIPTION
Updates to recent cut of `pathfinder_simd` to enable building on nightly