### PR TITLE
Add libfontconfig-dev dependency for version bump to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install
         run: |
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections;
-          sudo apt-get install ttf-mscorefonts-installer;
+          sudo apt-get install ttf-mscorefonts-installer libfontconfig-dev;
       - name: Build
         run: cargo build
       - name: Tests

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -108,7 +108,6 @@ impl Canvas {
             "src_stride must be >= than src_size.x()"
         );
 
-
         let dst_rect = RectI::new(dst_point, src_size);
         let dst_rect = dst_rect.intersection(RectI::new(Vector2I::default(), self.size));
         let dst_rect = match dst_rect {

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -107,7 +107,7 @@ impl Canvas {
             src_stride >= src_size.x() as usize * src_format.bytes_per_pixel() as usize,
             "src_stride must be >= than src_size.x()"
         );
-        
+
 
         let dst_rect = RectI::new(dst_point, src_size);
         let dst_rect = dst_rect.intersection(RectI::new(Vector2I::default(), self.size));

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -847,7 +847,7 @@ pub fn rasterize_glyph_with_full_hinting_subpixel() {
     )
     .unwrap();
     check_L_shape(&canvas);
-    
+
     // Test with larger canvas
     let mut canvas = Canvas::new(Vector2I::new(100, 100), Format::Rgb24);
     font.rasterize_glyph(
@@ -861,7 +861,6 @@ pub fn rasterize_glyph_with_full_hinting_subpixel() {
     .unwrap();
     check_L_shape(&canvas);
 }
-
 
 #[cfg(all(feature = "source", target_family = "windows"))]
 #[test]
@@ -942,7 +941,6 @@ pub fn rasterize_empty_glyph_on_empty_canvas() {
     )
     .unwrap();
 }
-
 
 #[cfg(feature = "source")]
 #[test]


### PR DESCRIPTION
It seems that fontconfig is no longer found with the ubuntu-latest runner, which has been bumped from 22.04 to 24.04 since the last CI run.

Installing libfontconfig-dev in the runner seems to fix this.