### PR TITLE
Fix Flatpak-specific paths

### DIFF
--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -221,12 +221,15 @@ fn default_font_directories() -> Vec<PathBuf> {
     let mut directories = vec![
         PathBuf::from("/usr/share/fonts"),
         PathBuf::from("/usr/local/share/fonts"),
-        PathBuf::from("/var/run/host/usr/share/fonts"), // Flatpak specific
-        PathBuf::from("/var/run/host/usr/local/share/fonts"),
+
+        // Flatpak specific
+        PathBuf::from("/run/host/fonts"),
+        PathBuf::from("/run/host/local-fonts"),
+        PathBuf::from("/run/host/user-fonts"),
     ];
     if let Some(path) = dirs::home_dir() {
         directories.push(path.join(".fonts")); // ~/.fonts is deprecated
-        directories.push(path.join("local").join("share").join("fonts")); // Flatpak specific
+        directories.push(path.join(".local").join("share").join("fonts"));
     }
     if let Some(mut path) = dirs::data_dir() {
         path.push("fonts");

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -221,7 +221,6 @@ fn default_font_directories() -> Vec<PathBuf> {
     let mut directories = vec![
         PathBuf::from("/usr/share/fonts"),
         PathBuf::from("/usr/local/share/fonts"),
-
         // Flatpak specific
         PathBuf::from("/run/host/fonts"),
         PathBuf::from("/run/host/local-fonts"),


### PR DESCRIPTION
Fixed Flatpak-specific paths to align with [Flatpak documentation](https://docs.flatpak.org/en/latest/desktop-integration.html#fonts).