### PR TITLE
Fix CoreText font width to CSS font stretch conversion

### DIFF
--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -806,7 +806,7 @@ fn core_text_to_css_font_weight(core_text_weight: f32) -> Weight {
 
 fn core_text_width_to_css_stretchiness(core_text_width: f32) -> Stretch {
     Stretch(piecewise_linear_lookup(
-        (core_text_width + 1.0) * 4.0,
+        ((core_text_width + 0.4) * 10.0).clamp(0.0, 8.0),
         &Stretch::MAPPING,
     ))
 }
@@ -970,13 +970,21 @@ mod test {
             Stretch(0.5)
         );
         assert_eq!(
+            super::core_text_width_to_css_stretchiness(-0.5),
+            Stretch(0.5)
+        );
+        assert_eq!(
+            super::core_text_width_to_css_stretchiness(0.5),
+            Stretch(2.0)
+        );
+        assert_eq!(
             super::core_text_width_to_css_stretchiness(1.0),
             Stretch(2.0)
         );
 
         // Linear interpolation
         assert_eq!(
-            super::core_text_width_to_css_stretchiness(0.85),
+            super::core_text_width_to_css_stretchiness(0.34),
             Stretch(1.7)
         );
     }

--- a/src/sources/core_text.rs
+++ b/src/sources/core_text.rs
@@ -150,7 +150,7 @@ fn css_to_core_text_font_weight(css_weight: Weight) -> f32 {
 #[allow(dead_code)]
 fn css_stretchiness_to_core_text_width(css_stretchiness: Stretch) -> f32 {
     let css_stretchiness = utils::clamp(css_stretchiness.0, 0.5, 2.0);
-    0.25 * core_text_loader::piecewise_linear_find_index(css_stretchiness, &Stretch::MAPPING) - 1.0
+    0.1 * core_text_loader::piecewise_linear_find_index(css_stretchiness, &Stretch::MAPPING) - 0.4
 }
 
 #[derive(Clone)]
@@ -286,17 +286,17 @@ mod test {
         );
         assert_eq!(
             super::css_stretchiness_to_core_text_width(Stretch(0.5)),
-            -1.0
+            -0.4
         );
         assert_eq!(
             super::css_stretchiness_to_core_text_width(Stretch(2.0)),
-            1.0
+            0.4
         );
 
         // Linear interpolation
         assert_eq!(
             super::css_stretchiness_to_core_text_width(Stretch(1.7)),
-            0.85
+            0.34
         );
     }
 }

--- a/src/sources/fs.rs
+++ b/src/sources/fs.rs
@@ -221,7 +221,6 @@ fn default_font_directories() -> Vec<PathBuf> {
     let mut directories = vec![
         PathBuf::from("/usr/share/fonts"),
         PathBuf::from("/usr/local/share/fonts"),
-
         // Flatpak specific
         PathBuf::from("/run/host/fonts"),
         PathBuf::from("/run/host/local-fonts"),


### PR DESCRIPTION
Fix issue: https://github.com/servo/font-kit/issues/258

Previous mapping was incorrect, using [-1, 1] to [0, 8]. Based on the values ranging from 'kCTFontWidthExtraCompressed' (-0.4) to 'kCTFontWidthUltraExpanded' (0.4), the corrected conversion maps CoreText font width values from [-0.4, 0.4] to [0, 8]