### PR TITLE
Upgrade dirs to 6.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ freetype-sys = "0.20"
 yeslogic-fontconfig-sys = "6.0"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android", target_env = "ohos")))'.dependencies]
-dirs = "5.0"
+dirs = "6.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 walkdir = "2.1"


### PR DESCRIPTION
The primary motivation for doing this is to move towards allowing Servo to eliminate older an version (0.48) of `windows-sys`.