### PR TITLE
remove unnecessary lazy_static dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ source = []
 bitflags = "2.4"
 byteorder = "1.2"
 float-ord = "0.3"
-lazy_static = "1.1"
 libc = "0.2"
 log = "0.4.4"
 pathfinder_geometry = "0.5"

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -10,7 +10,6 @@
 
 //! An in-memory bitmap surface for glyph rasterization.
 
-use lazy_static::lazy_static;
 use pathfinder_geometry::rect::RectI;
 use pathfinder_geometry::vector::Vector2I;
 use std::cmp;
@@ -18,21 +17,26 @@ use std::fmt;
 
 use crate::utils;
 
-lazy_static! {
-    static ref BITMAP_1BPP_TO_8BPP_LUT: [[u8; 8]; 256] = {
-        let mut lut = [[0; 8]; 256];
-        for byte in 0..0x100 {
-            let mut value = [0; 8];
-            for bit in 0..8 {
-                if (byte & (0x80 >> bit)) != 0 {
-                    value[bit] = 0xff;
-                }
+static BITMAP_1BPP_TO_8BPP_LUT: [[u8; 8]; 256] = {
+    let mut lut = [[0; 8]; 256];
+
+    let mut byte = 0;
+    while byte < 0x100 {
+        let mut value = [0; 8];
+
+        let mut bit = 0;
+        while bit < 8 {
+            if (byte & (0x80 >> bit)) != 0 {
+                value[bit] = 0xff;
             }
-            lut[byte] = value
+            bit += 1;
         }
-        lut
-    };
-}
+
+        lut[byte] = value;
+        byte += 1;
+    }
+    lut
+};
 
 /// An in-memory bitmap surface for glyph rasterization.
 pub struct Canvas {


### PR DESCRIPTION
you could replace the `lazy_static` dependency, by just replacing the `for` loop with a `while`. i tested it and it runs with rust 1.77 (the msrv of `font-kit`).

(note for review: the big diff is mostly due to losing a level of indentation, it's a lot smaller if you enable the "hide whitespace" option on github).