### PR TITLE
Run apt-get update in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install
         run: |
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections;
+          sudo apt-get update;
           sudo apt-get install ttf-mscorefonts-installer libfontconfig-dev;
       - name: Build
         run: cargo build


### PR DESCRIPTION
This ought to fix "mirror not found" issues when running `apt-get install` in Linux CI job.