### PR TITLE
exclude Android from fontconfig-sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ core-text = "20.1.0"
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 freetype-sys = "0.23"
 
-[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32", target_env = "ohos")))'.dependencies]
+[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_os = "android", target_arch = "wasm32", target_env = "ohos")))'.dependencies]
 yeslogic-fontconfig-sys = "6.0"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android", target_env = "ohos")))'.dependencies]

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -24,6 +24,7 @@ pub mod directwrite;
     not(any(
         target_os = "macos",
         target_os = "ios",
+        target_os = "android",
         target_family = "windows",
         target_arch = "wasm32",
         target_env = "ohos",


### PR DESCRIPTION
Android does not have fontconfig. Without this exclusion, cross-compiling for aarch64-linux-android fails because pkg-config cannot find fontconfig headers.