### PR TITLE
Exclude android for fontconfig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ core-text = "20.1.0"
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 freetype-sys = "0.23"
 
-[target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios", target_arch = "wasm32", target_env = "ohos")))'.dependencies]
+[target.'cfg(not(any(target_family = "windows", target_os = "android", target_os = "macos", target_os = "ios", target_arch = "wasm32", target_env = "ohos")))'.dependencies]
 yeslogic-fontconfig-sys = "6.0"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_family = "windows", target_os = "android", target_env = "ohos")))'.dependencies]

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -22,6 +22,7 @@ pub mod directwrite;
 
 #[cfg(any(
     not(any(
+        target_os = "android",
         target_os = "macos",
         target_os = "ios",
         target_family = "windows",


### PR DESCRIPTION
Probably closes https://github.com/servo/font-kit/issues/277

Pulling in font-kit as a dependency and running `cargo check --target aarch64-linux-android` fails without this patch but succeeds with it

Non-AI version of https://github.com/servo/font-kit/pull/276 (the changes are trivial but I did not copy/paste them from that PR)